### PR TITLE
Add basic web UI styled like a text RPG

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ Player characters are stored in `data/characters.yaml`. When `player.js` runs,
 enter a character name. If the name is not found, the character builder will
 prompt for choices defined in `data/character_builder.yaml` and save the new
 character before starting the player terminal.
+
+## Web UI
+
+A basic web interface is provided in the `web` directory. Open `web/index.html`
+ in a browser to try a simple menu styled in the spirit of classic text RPGs.
+The UI uses the [Pixelify Sans](https://fonts.google.com/specimen/Pixelify+Sans)
+font from Google Fonts.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Bloc Land Lands</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="container">
+    <header id="title">The Bloc Land Lands</header>
+    <main id="game">
+      <section id="output" class="panel">
+        <p>Welcome to the Bloc Land Lands.</p>
+      </section>
+      <aside id="menu" class="panel">
+        <button class="menu-option" data-action="start">Start New Game</button>
+        <button class="menu-option" data-action="load">Load Game</button>
+        <button class="menu-option" data-action="exit">Exit</button>
+      </aside>
+    </main>
+  </div>
+  <script src="ui.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  padding: 0;
+  background: #1b1a24;
+  color: #e0e0e0;
+  font-family: 'Pixelify Sans', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+#container {
+  width: 960px;
+  max-width: 90%;
+}
+
+#title {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+#game {
+  display: flex;
+  gap: 1rem;
+}
+
+.panel {
+  background: #26232f;
+  padding: 1rem;
+  border: 2px solid #4c4668;
+  height: 400px;
+  overflow-y: auto;
+}
+
+#output {
+  flex: 2 1 70%;
+}
+
+#menu {
+  flex: 1 1 30%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu-option {
+  font-family: inherit;
+  padding: 0.5rem;
+  background: #3b364d;
+  color: #e0e0e0;
+  border: 2px solid #4c4668;
+  cursor: pointer;
+}
+
+.menu-option:hover {
+  background: #4c4668;
+}

--- a/web/ui.js
+++ b/web/ui.js
@@ -1,0 +1,18 @@
+const output = document.getElementById('output');
+
+function append(text) {
+  const p = document.createElement('p');
+  p.textContent = text;
+  output.appendChild(p);
+  output.scrollTop = output.scrollHeight;
+}
+
+document.querySelectorAll('.menu-option').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const action = btn.dataset.action;
+    append(`Selected: ${btn.textContent}`);
+    if (action === 'exit') {
+      append('Thank you for playing.');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- create a new `web` directory with a minimal HTML interface
- style the UI in dark colors using Google Pixelify Sans font
- add simple script to log menu selections
- document the web UI in the README

## Testing
- `npm run player` *(fails: interactive prompt but shows working player terminal)*

------
https://chatgpt.com/codex/tasks/task_e_6863cb461ad88332b0e2604817a5616f