### PR TITLE
Add web menus and rulebook

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -15,9 +15,7 @@
         <p>Welcome to the Bloc Land Lands.</p>
       </section>
       <aside id="menu" class="panel">
-        <button class="menu-option" data-action="start">Start New Game</button>
-        <button class="menu-option" data-action="load">Load Game</button>
-        <button class="menu-option" data-action="exit">Exit</button>
+        <!-- menu options injected by ui.js -->
       </aside>
     </main>
   </div>

--- a/web/rulebook.html
+++ b/web/rulebook.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>The Bloc Land Lands Rulebook</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background: #1b1a24;
+      color: #e0e0e0;
+      font-family: 'Pixelify Sans', sans-serif;
+      padding: 2rem;
+    }
+    nav {
+      margin-bottom: 1rem;
+    }
+    nav a {
+      color: #9fa8da;
+      text-decoration: none;
+      display: block;
+      margin: 0.2rem 0;
+    }
+    nav a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <h1>The Bloc Land Lands Rulebook</h1>
+  <nav>
+    <strong>Table of Contents</strong>
+    <a href="#introduction">Introduction</a>
+    <a href="#creating-a-character">Creating a Character</a>
+    <a href="#gameplay">Gameplay</a>
+    <a href="#combat">Combat</a>
+  </nav>
+  <section id="introduction">
+    <h2>Introduction</h2>
+    <p>This rulebook outlines the basics of playing The Bloc Land Lands.</p>
+  </section>
+  <section id="creating-a-character">
+    <h2>Creating a Character</h2>
+    <p>Work with the guide to choose your background, alignment and subclass traits.</p>
+  </section>
+  <section id="gameplay">
+    <h2>Gameplay</h2>
+    <p>Players describe actions, the guide narrates the world and resolves outcomes.</p>
+  </section>
+  <section id="combat">
+    <h2>Combat</h2>
+    <p>Combat is turn based. Roll a die and compare results to determine success.</p>
+  </section>
+</body>
+</html>

--- a/web/ui.js
+++ b/web/ui.js
@@ -1,4 +1,5 @@
 const output = document.getElementById('output');
+const menu = document.getElementById('menu');
 
 function append(text) {
   const p = document.createElement('p');
@@ -7,12 +8,63 @@ function append(text) {
   output.scrollTop = output.scrollHeight;
 }
 
-document.querySelectorAll('.menu-option').forEach(btn => {
-  btn.addEventListener('click', () => {
-    const action = btn.dataset.action;
-    append(`Selected: ${btn.textContent}`);
-    if (action === 'exit') {
-      append('Thank you for playing.');
-    }
+const menus = {
+  main: [
+    { text: 'Player', action: 'showPlayer' },
+    { text: 'Guide', action: 'showGuide' },
+    { text: 'Rulebook', action: 'showRulebook' }
+  ],
+  player: [
+    { text: 'Start New Game', action: 'startPlayer' },
+    { text: 'Load Game', action: 'loadPlayer' },
+    { text: 'Back', action: 'showMain' }
+  ],
+  guide: [
+    { text: 'Start Guide Session', action: 'startGuide' },
+    { text: 'Back', action: 'showMain' }
+  ]
+};
+
+function showMenu(name) {
+  menu.innerHTML = '';
+  menus[name].forEach(item => {
+    const btn = document.createElement('button');
+    btn.className = 'menu-option';
+    btn.dataset.action = item.action;
+    btn.textContent = item.text;
+    btn.addEventListener('click', () => handleAction(item.action));
+    menu.appendChild(btn);
   });
-});
+}
+
+function handleAction(action) {
+  switch (action) {
+    case 'showPlayer':
+      append('Player menu');
+      showMenu('player');
+      break;
+    case 'showGuide':
+      append('Guide menu');
+      showMenu('guide');
+      break;
+    case 'showMain':
+      showMenu('main');
+      break;
+    case 'showRulebook':
+      window.open('rulebook.html', '_blank');
+      break;
+    case 'startPlayer':
+      append('Starting new game...');
+      break;
+    case 'loadPlayer':
+      append('Loading saved game...');
+      break;
+    case 'startGuide':
+      append('Starting guide session...');
+      break;
+    default:
+      append(`Unknown action: ${action}`);
+  }
+}
+
+showMenu('main');


### PR DESCRIPTION
## Summary
- add dynamic menus to main page with player, guide and rulebook options
- implement submenu logic in `ui.js`
- create simple rulebook with table of contents

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6863d2172f248332828b29c2df6525c3