### PR TITLE
Add server landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ character before starting the player terminal.
 ## Web UI
 
 A basic web interface is provided in the `web` directory. Open `web/index.html`
- in a browser to try a simple menu styled in the spirit of classic text RPGs.
+in a browser to try a simple menu styled in the spirit of classic text RPGs.
 The UI uses the [Pixelify Sans](https://fonts.google.com/specimen/Pixelify+Sans)
 font from Google Fonts.
+
+## Running the Web Server
+
+You can launch a simple HTTP server that serves the `web` directory. Start it
+with:
+
+```bash
+node server.js
+```
+
+The server listens on the port defined by the `PORT` environment variable (or
+`3000` by default) and provides a landing page with links to the player and
+guide options.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "player": "node terminals/player.js",
     "guide": "node terminals/guide.js",
-    "start": "node terminals/player.js"
+    "start": "node server.js"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,39 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+
+const port = process.env.PORT || 3000;
+const baseDir = path.join(__dirname, 'web');
+
+function getMime(file) {
+  const ext = path.extname(file);
+  switch (ext) {
+    case '.html': return 'text/html';
+    case '.css': return 'text/css';
+    case '.js': return 'text/javascript';
+    case '.png': return 'image/png';
+    case '.jpg':
+    case '.jpeg': return 'image/jpeg';
+    case '.gif': return 'image/gif';
+    default: return 'application/octet-stream';
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const reqPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(baseDir, reqPath);
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': getMime(filePath) });
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- create a small HTTP server that serves the `web` folder
- update `start` script to run the new server
- document how to launch the server in the README

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js >/tmp/server.log &`

------
https://chatgpt.com/codex/tasks/task_e_6863d4b095548332865d157e703905c5