### PR TITLE
Add web character creation and update fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ character before starting the player terminal.
 
 A basic web interface is provided in the `web` directory. Open `web/index.html`
 in a browser to try a simple menu styled in the spirit of classic text RPGs.
-The UI uses the [Pixelify Sans](https://fonts.google.com/specimen/Pixelify+Sans)
+The UI uses the [Jacquard 24](https://fonts.google.com/specimen/Jacquard+24)
 font from Google Fonts.
 
 ## Running the Web Server

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Bloc Land Lands</title>
-  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Jacquard+24&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/web/rulebook.html
+++ b/web/rulebook.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>The Bloc Land Lands Rulebook</title>
-  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Jacquard+24&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     body {
@@ -23,6 +23,9 @@
     }
     nav a:hover {
       text-decoration: underline;
+    }
+    h1, h2 {
+      font-family: 'Jacquard 24', cursive;
     }
   </style>
 </head>

--- a/web/style.css
+++ b/web/style.css
@@ -19,6 +19,7 @@ body {
   text-align: center;
   font-size: 2rem;
   margin-bottom: 1rem;
+  font-family: 'Jacquard 24', cursive;
 }
 
 #game {

--- a/web/ui.js
+++ b/web/ui.js
@@ -8,6 +8,56 @@ function append(text) {
   output.scrollTop = output.scrollHeight;
 }
 
+async function createPlayer() {
+  const name = prompt('Enter new player name:');
+  if (!name) return;
+
+  append(`Creating character '${name}'`);
+  const builder = await fetch('/api/builder').then(r => r.json());
+  const charData = {};
+
+  const rel = builder.religious_belief;
+  const relChoice = prompt(
+    rel.description + '\n' +
+      rel.options.map((o, i) => `${i + 1}) ${o.name}`).join('\n')
+  );
+  const relIdx = parseInt(relChoice, 10) - 1;
+  const selectedRel = rel.options[relIdx] || rel.options[0];
+  charData.religious_belief = selectedRel.name;
+  charData.languages = selectedRel.languages;
+
+  if (selectedRel.alignment && selectedRel.alignment.options) {
+    const alignChoice = prompt(
+      'Choose alignment:\n' +
+        selectedRel.alignment.options
+          .map((o, i) => `${i + 1}) ${o}`)
+          .join('\n')
+    );
+    const alignIdx = parseInt(alignChoice, 10) - 1;
+    charData.alignment =
+      selectedRel.alignment.options[alignIdx] ||
+      selectedRel.alignment.options[0];
+  }
+
+  const fam = builder.family_background;
+  const famChoice = prompt(
+    fam.description + '\n' +
+      fam.options.map((o, i) => `${i + 1}) ${o.name}`).join('\n')
+  );
+  const famIdx = parseInt(famChoice, 10) - 1;
+  const selectedFam = fam.options[famIdx] || fam.options[0];
+  charData.family_background = selectedFam.name;
+  charData.subclass_traits = selectedFam.subclass_traits;
+
+  await fetch('/api/characters', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, data: charData })
+  });
+
+  append(`Character '${name}' created.`);
+}
+
 const menus = {
   main: [
     { text: 'Player', action: 'showPlayer' },
@@ -15,7 +65,7 @@ const menus = {
     { text: 'Rulebook', action: 'showRulebook' }
   ],
   player: [
-    { text: 'Start New Game', action: 'startPlayer' },
+    { text: 'New Player', action: 'newPlayer' },
     { text: 'Load Game', action: 'loadPlayer' },
     { text: 'Back', action: 'showMain' }
   ],
@@ -55,6 +105,9 @@ function handleAction(action) {
       break;
     case 'startPlayer':
       append('Starting new game...');
+      break;
+    case 'newPlayer':
+      createPlayer();
       break;
     case 'loadPlayer':
       append('Loading saved game...');


### PR DESCRIPTION
## Summary
- serve character builder and save characters through API endpoints
- implement new player creation flow in the web UI
- use Jacquard 24 for page headers

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6863d9ca32a48332820601b9e144af96