### PR TITLE
Implement in-page character creation and menu

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,6 +36,29 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  if (req.method === 'GET' && req.url.startsWith('/api/characters')) {
+    const urlObj = new URL(req.url, `http://${req.headers.host}`);
+    const name = urlObj.searchParams.get('name');
+    const charPath = path.join(dataDir, 'characters.yaml');
+    try {
+      const chars = fs.existsSync(charPath)
+        ? yaml.load(fs.readFileSync(charPath, 'utf8')) || {}
+        : {};
+      const result = name ? chars[name] : chars;
+      if (!result) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Character not found');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('Failed to load character');
+    }
+    return;
+  }
+
   if (req.method === 'POST' && req.url === '/api/characters') {
     let body = '';
     req.on('data', chunk => (body += chunk));

--- a/web/index.html
+++ b/web/index.html
@@ -17,6 +17,7 @@
       <aside id="menu" class="panel">
         <!-- menu options injected by ui.js -->
       </aside>
+      <section id="creator" class="panel" style="display:none"></section>
     </main>
   </div>
   <script src="ui.js"></script>

--- a/web/style.css
+++ b/web/style.css
@@ -27,6 +27,10 @@ body {
   gap: 1rem;
 }
 
+#creator {
+  flex: 1 1 100%;
+}
+
 .panel {
   background: #26232f;
   padding: 1rem;
@@ -44,6 +48,25 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.form-field {
+  margin-bottom: 0.5rem;
+}
+
+.form-field label {
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.form-field input,
+.form-field select {
+  width: 100%;
+  padding: 0.3rem;
+  font-family: inherit;
+  background: #3b364d;
+  color: #e0e0e0;
+  border: 2px solid #4c4668;
 }
 
 .menu-option {

--- a/web/ui.js
+++ b/web/ui.js
@@ -1,5 +1,9 @@
 const output = document.getElementById('output');
 const menu = document.getElementById('menu');
+const creator = document.getElementById('creator');
+
+let builderData = null;
+let currentCharacter = null;
 
 function append(text) {
   const p = document.createElement('p');
@@ -8,46 +12,107 @@ function append(text) {
   output.scrollTop = output.scrollHeight;
 }
 
-async function createPlayer() {
-  const name = prompt('Enter new player name:');
-  if (!name) return;
+async function showCreatorForm() {
+  output.style.display = 'none';
+  menu.style.display = 'none';
+  creator.style.display = 'block';
+  creator.innerHTML = '';
 
-  append(`Creating character '${name}'`);
-  const builder = await fetch('/api/builder').then(r => r.json());
-  const charData = {};
+  builderData = await fetch('/api/builder').then(r => r.json());
 
-  const rel = builder.religious_belief;
-  const relChoice = prompt(
-    rel.description + '\n' +
-      rel.options.map((o, i) => `${i + 1}) ${o.name}`).join('\n')
-  );
-  const relIdx = parseInt(relChoice, 10) - 1;
-  const selectedRel = rel.options[relIdx] || rel.options[0];
-  charData.religious_belief = selectedRel.name;
-  charData.languages = selectedRel.languages;
+  const form = document.createElement('form');
+  form.id = 'charForm';
+  form.innerHTML = `
+    <div class="form-field">
+      <label for="char-name">Name</label>
+      <input id="char-name" type="text" required />
+    </div>
+    <div class="form-field">
+      <label for="rel-select">Religious Belief</label>
+      <select id="rel-select"></select>
+    </div>
+    <div class="form-field" id="align-field" style="display:none">
+      <label for="align-select">Alignment</label>
+      <select id="align-select"></select>
+    </div>
+    <div class="form-field">
+      <label for="fam-select">Family Background</label>
+      <select id="fam-select"></select>
+    </div>
+    <button class="menu-option" type="submit">Create</button>
+  `;
+  creator.appendChild(form);
 
-  if (selectedRel.alignment && selectedRel.alignment.options) {
-    const alignChoice = prompt(
-      'Choose alignment:\n' +
-        selectedRel.alignment.options
-          .map((o, i) => `${i + 1}) ${o}`)
-          .join('\n')
-    );
-    const alignIdx = parseInt(alignChoice, 10) - 1;
-    charData.alignment =
-      selectedRel.alignment.options[alignIdx] ||
-      selectedRel.alignment.options[0];
+  const relSelect = form.querySelector('#rel-select');
+  builderData.religious_belief.options.forEach((opt, i) => {
+    const o = document.createElement('option');
+    o.value = i;
+    o.textContent = opt.name;
+    relSelect.appendChild(o);
+  });
+
+  const famSelect = form.querySelector('#fam-select');
+  builderData.family_background.options.forEach((opt, i) => {
+    const o = document.createElement('option');
+    o.value = i;
+    o.textContent = opt.name;
+    famSelect.appendChild(o);
+  });
+
+  const alignField = form.querySelector('#align-field');
+  const alignSelect = form.querySelector('#align-select');
+
+  function updateAlignment() {
+    const rel = builderData.religious_belief.options[relSelect.value];
+    if (rel.alignment && rel.alignment.options) {
+      alignField.style.display = 'block';
+      alignSelect.innerHTML = '';
+      rel.alignment.options.forEach((opt, i) => {
+        const o = document.createElement('option');
+        o.value = i;
+        o.textContent = opt;
+        alignSelect.appendChild(o);
+      });
+    } else {
+      alignField.style.display = 'none';
+      alignSelect.innerHTML = '';
+    }
   }
 
-  const fam = builder.family_background;
-  const famChoice = prompt(
-    fam.description + '\n' +
-      fam.options.map((o, i) => `${i + 1}) ${o.name}`).join('\n')
-  );
-  const famIdx = parseInt(famChoice, 10) - 1;
-  const selectedFam = fam.options[famIdx] || fam.options[0];
-  charData.family_background = selectedFam.name;
-  charData.subclass_traits = selectedFam.subclass_traits;
+  relSelect.addEventListener('change', updateAlignment);
+  updateAlignment();
+
+  form.addEventListener('submit', createPlayerFromForm);
+}
+
+async function createPlayerFromForm(e) {
+  e.preventDefault();
+  const name = document.getElementById('char-name').value.trim();
+  if (!name) return;
+
+  const relIdx = parseInt(document.getElementById('rel-select').value, 10);
+  const rel = builderData.religious_belief.options[relIdx];
+  const famIdx = parseInt(document.getElementById('fam-select').value, 10);
+  const fam = builderData.family_background.options[famIdx];
+
+  let alignment;
+  const alignField = document.getElementById('align-field');
+  if (alignField.style.display !== 'none') {
+    const aIdx = parseInt(document.getElementById('align-select').value, 10);
+    alignment = rel.alignment.options[aIdx];
+  }
+
+  const charData = {
+    religious_belief: rel.name,
+    languages: rel.languages,
+    family_background: fam.name,
+    subclass_traits: fam.subclass_traits,
+    hp: 6,
+    level: 1,
+    inventory: []
+  };
+
+  if (alignment) charData.alignment = alignment;
 
   await fetch('/api/characters', {
     method: 'POST',
@@ -55,7 +120,12 @@ async function createPlayer() {
     body: JSON.stringify({ name, data: charData })
   });
 
+  currentCharacter = { name, ...charData };
   append(`Character '${name}' created.`);
+  creator.style.display = 'none';
+  output.style.display = '';
+  menu.style.display = 'flex';
+  showMenu('character');
 }
 
 const menus = {
@@ -72,6 +142,13 @@ const menus = {
   guide: [
     { text: 'Start Guide Session', action: 'startGuide' },
     { text: 'Back', action: 'showMain' }
+  ],
+  character: [
+    { text: 'Character Sheet', action: 'showSheet' },
+    { text: 'Inventory', action: 'showInventory' },
+    { text: 'Journal', action: 'showJournal' },
+    { text: 'Map', action: 'showMap' },
+    { text: 'Back', action: 'showMain' }
   ]
 };
 
@@ -85,6 +162,36 @@ function showMenu(name) {
     btn.addEventListener('click', () => handleAction(item.action));
     menu.appendChild(btn);
   });
+}
+
+function showSheet() {
+  if (!currentCharacter) {
+    append('No character loaded.');
+    return;
+  }
+  append('--- Character Sheet ---');
+  Object.entries(currentCharacter).forEach(([k, v]) => {
+    if (k === 'inventory') return;
+    const val = Array.isArray(v) ? v.join(', ') : v;
+    append(`${k}: ${val}`);
+  });
+}
+
+function showInventory() {
+  if (!currentCharacter) {
+    append('No character loaded.');
+    return;
+  }
+  const items = currentCharacter.inventory || [];
+  append('Inventory: ' + (items.length ? items.join(', ') : 'Empty'));
+}
+
+function showJournal() {
+  append('Journal feature coming soon.');
+}
+
+function showMap() {
+  append('Map feature coming soon.');
 }
 
 function handleAction(action) {
@@ -107,13 +214,25 @@ function handleAction(action) {
       append('Starting new game...');
       break;
     case 'newPlayer':
-      createPlayer();
+      showCreatorForm();
       break;
     case 'loadPlayer':
       append('Loading saved game...');
       break;
     case 'startGuide':
       append('Starting guide session...');
+      break;
+    case 'showSheet':
+      showSheet();
+      break;
+    case 'showInventory':
+      showInventory();
+      break;
+    case 'showJournal':
+      showJournal();
+      break;
+    case 'showMap':
+      showMap();
       break;
     default:
       append(`Unknown action: ${action}`);


### PR DESCRIPTION
## Summary
- add API endpoint to fetch stored characters
- embed a creator panel into index page
- style character creation form
- overhaul UI logic for character creation

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(starts and stops)*

------
https://chatgpt.com/codex/tasks/task_e_6863dcad87ac8332a01e940eac16f5d4