### PR TITLE
Add starting gear and encumbrance rules

### DIFF
--- a/data/character_builder.yaml
+++ b/data/character_builder.yaml
@@ -122,3 +122,29 @@ character_builder:
           cost_skott: 0
         - name: Feather Headdress
           cost_skott: 20
+
+    starting_gear:
+      universal_items:
+        - name: Rations
+          quantity: 3
+        - name: Bedroll
+          durability: average
+        - name: Tent
+          durability: average
+        - name: Pouch
+          slots: "+2 inventory slots"
+        - name: Backpack
+          slots: "+6 inventory slots"
+        - name: Lantern
+          durability: average
+        - name: Flint Box
+      durability_rules:
+        description: >
+          Items with durability (e.g., tent, bedroll, lantern) start at average condition. Exposure to harsh weather, poor storage, or overuse may reduce durability to poor. Once at poor, any additional damage or neglect destroys the item.
+        ratings:
+          - Good: fully functional, no penalties.
+          - Average: standard starting condition.
+          - Poor: disadvantage when using item, e.g., tent leaks; must repair soon.
+        repair:
+          requirement: Characters with Repair trait may attempt repair.
+          mechanic: Roll d6; 5-6 restores item from poor to average, or average to good. Failed repairs have no effect.

--- a/lib/player.js
+++ b/lib/player.js
@@ -4,6 +4,28 @@ const yaml = require('js-yaml');
 const readline = require('readline');
 const runTerminal = require('./terminal');
 
+function formatItem(item) {
+  let name = item.name;
+  if (item.quantity) name += ` x${item.quantity}`;
+  if (item.durability) name += ` (${item.durability})`;
+  return name;
+}
+
+function computeMaxSlots(items) {
+  let slots = 12;
+  items.forEach(n => {
+    const l = n.toLowerCase();
+    if (l.includes('backpack')) slots += 4;
+    if (l.includes('pouch')) slots += 2;
+  });
+  return slots;
+}
+
+function applyEncumbrance(data) {
+  data.max_slots = computeMaxSlots(data.inventory);
+  data.encumbered = data.inventory.length > data.max_slots;
+}
+
 function loadYaml(filePath, defaultValue) {
   try {
     const data = fs.readFileSync(filePath, 'utf8');
@@ -70,6 +92,12 @@ async function buildCharacter(name, builder, charactersPath, characters, rl) {
     charData.traits[t] = 5;
   });
 
+  if (builder.starting_gear && builder.starting_gear.universal_items) {
+    builder.starting_gear.universal_items.forEach(it => {
+      charData.inventory.push(formatItem(it));
+    });
+  }
+
   if (builder.item_shop) {
     console.log('--- Item Shop ---');
     for (const [category, items] of Object.entries(builder.item_shop)) {
@@ -85,6 +113,8 @@ async function buildCharacter(name, builder, charactersPath, characters, rl) {
       }
     }
   }
+
+  applyEncumbrance(charData);
 
   characters[name] = charData;
   saveYaml(charactersPath, characters);
@@ -108,6 +138,7 @@ async function start() {
 
   if (characters[name]) {
     console.log(`Welcome back, ${name}!`);
+    applyEncumbrance(characters[name]);
     console.log('Loaded character:', JSON.stringify(characters[name], null, 2));
   } else {
     console.log(`Creating new character '${name}'.`);

--- a/web/rulebook.html
+++ b/web/rulebook.html
@@ -37,6 +37,7 @@
     <a href="#creating-a-character">Creating a Character</a>
     <a href="#gameplay">Gameplay</a>
     <a href="#combat">Combat</a>
+    <a href="#equipment">Equipment &amp; Encumbrance</a>
   </nav>
   <section id="introduction">
     <h2>Introduction</h2>
@@ -54,5 +55,36 @@
     <h2>Combat</h2>
     <p>Combat is turn based. Roll a die and compare results to determine success.</p>
   </section>
+  <section id="equipment">
+    <h2>Equipment &amp; Encumbrance</h2>
+    <p>Starting characters receive:</p>
+    <ul>
+      <li>Rations x3</li>
+      <li>Bedroll (Average)</li>
+      <li>Tent (Average)</li>
+      <li>Pouch (+2 slots)</li>
+      <li>Backpack (+4 slots)</li>
+      <li>Lantern (Average)</li>
+      <li>Flint Box</li>
+    </ul>
+    <p>Everyone has 12 inventory slots. A backpack adds 4 and a pouch adds 2. Carrying more items than your slots causes disadvantage on physical tasks.</p>
+    <p>Items with durability begin at Average. Harsh use can drop them to Poor. Characters with the Repair trait may roll a d6&mdash;on 5-6 the item improves one step.</p>
+  </section>
+  <script>
+    const sections = document.querySelectorAll('section');
+    function show(id) {
+      sections.forEach(s => s.style.display = 'none');
+      const el = document.getElementById(id);
+      if (el) el.style.display = 'block';
+    }
+    document.querySelectorAll('nav a').forEach(a => {
+      const id = a.getAttribute('href').slice(1);
+      a.addEventListener('click', e => {
+        e.preventDefault();
+        show(id);
+      });
+    });
+    show('introduction');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- define starting gear and durability rules
- track encumbrance for characters
- show starting gear in UI and CLI builds
- add Equipment section in rulebook with show/hide navigation

## Testing
- `node -e "require('./lib/player.js');"`

------
https://chatgpt.com/codex/tasks/task_e_6863e96be9e88332908df9d22730d879