### PR TITLE
Add encumbrance and sin rules

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -23,6 +23,7 @@ function computeMaxSlots(items) {
 
 function applyEncumbrance(data) {
   data.max_slots = computeMaxSlots(data.inventory);
+  data.encumber_limit = data.max_slots + 2;
   data.encumbered = data.inventory.length > data.max_slots;
 }
 
@@ -47,7 +48,7 @@ function ask(rl, question) {
 }
 
 async function buildCharacter(name, builder, charactersPath, characters, rl) {
-  const charData = { inventory: [] };
+  const charData = { inventory: [], sin: 0 };
 
   const rel = builder.religious_belief;
   console.log(rel.description);

--- a/web/rulebook.html
+++ b/web/rulebook.html
@@ -39,7 +39,8 @@
             <li>Lantern (Average)</li>
             <li>Flint Box</li>
           </ul>
-          <p>Everyone has 12 inventory slots. A backpack adds 4 and a pouch adds 2. Carrying more items than your slots causes disadvantage on physical tasks.</p>
+          <p>Everyone has 12 inventory slots. A backpack adds 4 and a pouch adds 2. Two additional encumbrance slots may be used beyond this total&mdash;no more can be carried. Items in these slots make the character <em>encumbered</em>, causing disadvantage on physical tasks.</p>
+          <p>While encumbered, traveling across a hex requires one extra Travel Point.</p>
           <p>Items with durability begin at Average. Harsh use can drop them to Poor. Characters with the Repair trait may roll a d6&mdash;on 5-6 the item improves one step.</p>
         </section>
         <section id="hex-travel">
@@ -52,6 +53,7 @@
             <li><strong>Hunt, Forage or Fish</strong> &ndash; each action slot rolls a d6; only a 6 gathers food or ingredients.</li>
             <li><strong>Camp</strong> &ndash; rest and eat. Cooking may draw beasts on a d6 roll.</li>
           </ul>
+          <p>Camping should take place at night. Skipping camp gives a fatigue penalty the next day. Rations are eaten at night as well; failing to do so causes hunger.</p>
           <p>After every action the guide secretly rolls the event die:</p>
           <ol>
             <li>Wild Encounter</li>
@@ -62,6 +64,13 @@
             <li>Discovery</li>
           </ol>
         </section>
+        <section id="sin">
+          <h2>Sin and Nightmares</h2>
+          <p>Each character tracks a <strong>Sin</strong> score on their sheet. The guide may add points when actions defy morality or the character's alignment.</p>
+          <p>At the end of each day the player rolls a d20 for rest. For every sin point they also roll a "nightmare" die. Rolling both a 1 on the rest die and at least one 1 on the nightmare dice means no rest is gained.</p>
+          <p>Characters without a religion roll two dice for the rest check and may ask another player for forgiveness&mdash;if that player performs a ritual the sin is removed.</p>
+          <p>Monotheists remove a sin by self-flagellating with a whip, losing 1d4 HP. Polytheists must leave a fitting tribute at a sacred site, permanently losing the offered item.</p>
+        </section>
       </section>
       <aside id="rule-menu" class="panel">
         <strong>Table of Contents</strong>
@@ -71,6 +80,7 @@
         <a href="#combat">Combat</a>
         <a href="#equipment">Equipment &amp; Encumbrance</a>
         <a href="#hex-travel">Hex Travel</a>
+        <a href="#sin">Sin and Nightmares</a>
       </aside>
     </main>
   </div>

--- a/web/ui.js
+++ b/web/ui.js
@@ -21,7 +21,7 @@ async function autoLoadPlayer() {
     if (l.includes('backpack')) max += 4;
     if (l.includes('pouch')) max += 2;
   });
-  currentCharacter = { name, ...data, max_slots: max, encumbered: inv.length > max };
+  currentCharacter = { name, ...data, max_slots: max, encumber_limit: max + 2, encumbered: inv.length > max };
 }
 
 function append(text) {
@@ -170,6 +170,7 @@ function showStore(name, charData) {
       if (l.includes('backpack')) charData.max_slots += 4;
       if (l.includes('pouch')) charData.max_slots += 2;
     });
+    charData.encumber_limit = charData.max_slots + 2;
     charData.encumbered = charData.inventory.length > charData.max_slots;
 
     await fetch('/api/characters', {
@@ -212,6 +213,7 @@ async function createPlayerFromForm(e) {
     subclass_traits: fam.subclass_traits,
     hp: 6,
     sp: 0,
+    sin: 0,
     level: 1,
     inventory: []
   };
@@ -259,7 +261,7 @@ async function loadPlayer() {
     if (l.includes('backpack')) max += 4;
     if (l.includes('pouch')) max += 2;
   });
-  currentCharacter = { name, ...data, max_slots: max, encumbered: inv.length > max };
+  currentCharacter = { name, ...data, max_slots: max, encumber_limit: max + 2, encumbered: inv.length > max };
   localStorage.setItem('currentCharacter', name);
   append(`Loaded ${name}.`);
   showMenu('character');
@@ -316,11 +318,15 @@ function editPlayer(name, data) {
   const spField = document.createElement('div');
   spField.className = 'form-field';
   spField.innerHTML = `<label>SP</label><input id="sp" type="number" value="${data.sp || 0}" />`;
+  const sinField = document.createElement('div');
+  sinField.className = 'form-field';
+  sinField.innerHTML = `<label>Sin</label><input id="sin" type="number" value="${data.sin || 0}" />`;
   const invField = document.createElement('div');
   invField.className = 'form-field';
   invField.innerHTML = `<label>Inventory</label><input id="inv" type="text" value="${(data.inventory || []).join(', ')}" />`;
   form.appendChild(hpField);
   form.appendChild(spField);
+  form.appendChild(sinField);
   form.appendChild(invField);
 
   if (data.traits) {
@@ -342,6 +348,7 @@ function editPlayer(name, data) {
     const updates = {
       hp: parseInt(form.querySelector('#hp').value, 10),
       sp: parseInt(form.querySelector('#sp').value, 10),
+      sin: parseInt(form.querySelector('#sin').value, 10),
       inventory: form.querySelector('#inv').value.split(',').map(s => s.trim()).filter(Boolean)
     };
     if (data.traits) {
@@ -461,7 +468,8 @@ function showInventory() {
   output.innerHTML = '';
   const items = currentCharacter.inventory || [];
   const max = currentCharacter.max_slots || 12;
-  append(`Inventory (${items.length}/${max})` + (currentCharacter.encumbered ? ' - Encumbered!' : ''));
+  const limit = currentCharacter.encumber_limit || (max + 2);
+  append(`Inventory (${items.length}/${limit})` + (currentCharacter.encumbered ? ' - Encumbered!' : ''));
   if (items.length) {
     items.forEach(it => append('- ' + it));
   } else {


### PR DESCRIPTION
## Summary
- extend inventory logic to handle encumbrance limit
- track sin on characters and expose editing field
- document encumbrance, camping, and sin/nightmare system in rulebook

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863fbaa15bc8332abf1d9242e228819