### PR TITLE
Improve hex tools

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -20,7 +20,10 @@
       <section id="creator" class="panel" style="display:none"></section>
       <section id="guide-edit" class="panel" style="display:none"></section>
       <section id="story" class="panel" style="display:none"></section>
-      <section id="hex-gen" class="panel" style="display:none"></section>
+      <section id="hex-gen" style="display:none">
+        <section id="hex-content" class="panel"></section>
+        <aside id="hex-menu" class="panel"></aside>
+      </section>
     </main>
   </div>
   <script src="ui.js"></script>

--- a/web/style.css
+++ b/web/style.css
@@ -53,6 +53,19 @@ body {
 
 #hex-gen {
   flex: 2 1 70%;
+  display: flex;
+  gap: 1rem;
+}
+
+#hex-content {
+  flex: 2 1 70%;
+}
+
+#hex-menu {
+  flex: 1 1 30%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 #player-map button {
@@ -61,6 +74,34 @@ body {
 
 #hex-grid button {
   width: 100%;
+}
+
+#hex-grid {
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+}
+
+.hex-row {
+  display: flex;
+  column-gap: 4px;
+}
+
+.hex-row.offset {
+  margin-left: 30px;
+}
+
+.hex-cell {
+  width: 60px;
+  height: 52px;
+  clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+  background: #3b364d;
+  color: #e0e0e0;
+  border: 2px solid #4c4668;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
 }
 
 #rule-content {

--- a/web/ui.js
+++ b/web/ui.js
@@ -4,6 +4,8 @@ const creator = document.getElementById('creator');
 const guideEdit = document.getElementById('guide-edit');
 const storyPanel = document.getElementById('story');
 const hexGenPanel = document.getElementById('hex-gen');
+const hexContent = document.getElementById('hex-content');
+const hexMenu = document.getElementById('hex-menu');
 
 let builderData = null;
 let currentCharacter = null;
@@ -400,7 +402,7 @@ const menus = {
     { text: 'Rulebook', action: 'showRulebook' }
   ],
   player: [
-    { text: 'New Player', action: 'newPlayer' },
+    { text: 'New Character', action: 'newPlayer' },
     { text: 'Load Game', action: 'loadPlayer' },
     { text: 'Story Dialogue', action: 'showStory' },
     { text: 'Back', action: 'showMain' }
@@ -646,61 +648,69 @@ function showHexMenu() {
   creator.style.display = 'none';
   guideEdit.style.display = 'none';
   storyPanel.style.display = 'none';
-  hexGenPanel.style.display = 'block';
-  hexGenPanel.innerHTML = '';
+  hexGenPanel.style.display = 'flex';
+  hexContent.innerHTML = '';
+  hexMenu.innerHTML = '';
 
   const gen = document.createElement('button');
   gen.className = 'menu-option';
   gen.textContent = 'Generate Hex';
   gen.addEventListener('click', showHexGenerator);
-  hexGenPanel.appendChild(gen);
+  hexMenu.appendChild(gen);
 
   const list = document.createElement('button');
   list.className = 'menu-option';
   list.textContent = 'Hex List';
   list.addEventListener('click', showHexList);
-  hexGenPanel.appendChild(list);
+  hexMenu.appendChild(list);
 
   const map = document.createElement('button');
   map.className = 'menu-option';
   map.textContent = 'Hex Map';
   map.addEventListener('click', showHexMap);
-  hexGenPanel.appendChild(map);
+  hexMenu.appendChild(map);
 
   const back = document.createElement('button');
   back.className = 'menu-option';
   back.textContent = 'Back';
   back.addEventListener('click', () => {
     hexGenPanel.style.display = 'none';
-    showHexMenu();
+    showMenu('guide');
   });
-  hexGenPanel.appendChild(back);
+  hexMenu.appendChild(back);
 }
 
 async function showHexList() {
   const hx = await fetch('/api/hexes').then(r => r.json());
-  hexGenPanel.innerHTML = '';
-  Object.keys(hx).sort().forEach(num => {
+  hexContent.innerHTML = '';
+  const nums = [];
+  for (let i = 1; i <= 25; i++) {
+    nums.push(i.toString().padStart(3, '0'));
+  }
+  Object.keys(hx).forEach(n => {
+    if (!nums.includes(n)) nums.push(n);
+  });
+  nums.sort();
+  nums.forEach(num => {
     const btn = document.createElement('button');
     btn.className = 'menu-option';
     btn.textContent = num;
     btn.addEventListener('click', () => editHex(num));
-    hexGenPanel.appendChild(btn);
+    hexContent.appendChild(btn);
   });
   const back = document.createElement('button');
   back.className = 'menu-option';
   back.textContent = 'Back';
   back.addEventListener('click', showHexMenu);
-  hexGenPanel.appendChild(back);
+  hexContent.appendChild(back);
 }
 
 function editHex(num) {
   fetch('/api/hexes')
     .then(r => r.json())
     .then(all => {
-      const hx = all[num];
-      if (!hx) return;
-      hexGenPanel.innerHTML = '';
+      const hx = all[num] || { hex: num };
+      hexContent.innerHTML = '';
       const form = document.createElement('form');
       Object.entries(hx).forEach(([k, v]) => {
         const f = document.createElement('div');
@@ -714,44 +724,48 @@ function editHex(num) {
       form.appendChild(submit);
       form.addEventListener('submit', async e => {
         e.preventDefault();
-        const data = {};
-        new FormData(form).forEach((v, k) => (data[k] = v));
+        const payload = {};
+        new FormData(form).forEach((v, k) => (payload[k] = v));
         await fetch('/api/hex/save', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data)
+          body: JSON.stringify(payload)
         });
         showHexList();
       });
-      hexGenPanel.appendChild(form);
+      hexContent.appendChild(form);
       const back = document.createElement('button');
       back.className = 'menu-option';
       back.textContent = 'Back';
       back.addEventListener('click', showHexList);
-      hexGenPanel.appendChild(back);
+      hexContent.appendChild(back);
     });
 }
 
 function showHexMap() {
-  hexGenPanel.innerHTML = '';
+  hexContent.innerHTML = '';
   const grid = document.createElement('div');
   grid.id = 'hex-grid';
-  grid.style.display = 'grid';
-  grid.style.gridTemplateColumns = 'repeat(5, 1fr)';
-  for (let i = 1; i <= 25; i++) {
-    const num = i.toString().padStart(3, '0');
-    const cell = document.createElement('button');
-    cell.className = 'menu-option';
-    cell.textContent = num;
-    cell.addEventListener('click', () => editHex(num));
-    grid.appendChild(cell);
+  for (let r = 0; r < 5; r++) {
+    const row = document.createElement('div');
+    row.className = 'hex-row';
+    if (r % 2 === 1) row.classList.add('offset');
+    for (let c = 0; c < 5; c++) {
+      const num = (r * 5 + c + 1).toString().padStart(3, '0');
+      const cell = document.createElement('div');
+      cell.className = 'hex-cell';
+      cell.textContent = num;
+      cell.addEventListener('click', () => editHex(num));
+      row.appendChild(cell);
+    }
+    grid.appendChild(row);
   }
-  hexGenPanel.appendChild(grid);
+  hexContent.appendChild(grid);
   const back = document.createElement('button');
   back.className = 'menu-option';
   back.textContent = 'Back';
   back.addEventListener('click', showHexMenu);
-  hexGenPanel.appendChild(back);
+  hexContent.appendChild(back);
 }
 
 async function showHexGenerator() {
@@ -759,17 +773,63 @@ async function showHexGenerator() {
   creator.style.display = 'none';
   guideEdit.style.display = 'none';
   storyPanel.style.display = 'none';
-  hexGenPanel.style.display = 'block';
-  hexGenPanel.innerHTML = '';
+  hexGenPanel.style.display = 'flex';
+  hexContent.innerHTML = '';
+  hexMenu.innerHTML = '';
+
+  const data = await fetch('/api/hex-generator').then(r => r.json());
+
+  const tables = document.createElement('div');
+  tables.id = 'hex-tables';
+  hexContent.appendChild(tables);
+
+  function renderTable(title, obj) {
+    const div = document.createElement('div');
+    const h3 = document.createElement('h3');
+    h3.textContent = title;
+    div.appendChild(h3);
+    const ul = document.createElement('ul');
+    Object.entries(obj).forEach(([k, v]) => {
+      const li = document.createElement('li');
+      li.textContent = `${k}: ${v}`;
+      ul.appendChild(li);
+    });
+    div.appendChild(ul);
+    tables.appendChild(div);
+  }
+
+  if (data.hex_generator && data.hex_generator.create_hex) {
+    const ch = data.hex_generator.create_hex;
+    const p = document.createElement('p');
+    p.textContent = ch.description;
+    tables.appendChild(p);
+    renderTable('Biome Table', ch.biome_table);
+    renderTable('Terrain Features', ch.terrain_features.d20);
+    renderTable('Region Qualities', ch.region_qualities.d20);
+  }
+
+  if (data.hex_generator && data.hex_generator.random_tables) {
+    const rt = data.hex_generator.random_tables;
+    renderTable('Flora', rt.flora.d6);
+    renderTable('Fauna', rt.fauna.d6);
+    renderTable('Fish', rt.fish.d6);
+  }
+
+  if (data.hex_generator && data.hex_generator.animal_feature_table) {
+    renderTable('Animal Features', data.hex_generator.animal_feature_table.d100);
+  }
+  if (data.hex_generator && data.hex_generator.flora_feature_table) {
+    renderTable('Flora Features', data.hex_generator.flora_feature_table.d20);
+  }
 
   const genBtn = document.createElement('button');
   genBtn.className = 'menu-option';
   genBtn.textContent = 'Generate Hex';
-  hexGenPanel.appendChild(genBtn);
+  hexMenu.appendChild(genBtn);
 
   const form = document.createElement('form');
   form.style.display = 'none';
-  hexGenPanel.appendChild(form);
+  hexContent.appendChild(form);
 
   genBtn.addEventListener('click', async () => {
     const hx = await fetch('/api/hex/generate').then(r => r.json());
@@ -789,14 +849,14 @@ async function showHexGenerator() {
 
   form.addEventListener('submit', async e => {
     e.preventDefault();
-    const data = {};
-    new FormData(form).forEach((v, k) => (data[k] = v));
+    const payload = {};
+    new FormData(form).forEach((v, k) => (payload[k] = v));
     await fetch('/api/hex/save', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
+      body: JSON.stringify(payload)
     });
-    hexGenPanel.innerHTML = 'Saved.';
+    hexContent.innerHTML = 'Saved.';
   });
 
   const back = document.createElement('button');
@@ -806,7 +866,7 @@ async function showHexGenerator() {
     hexGenPanel.style.display = 'none';
     showMenu('guide');
   });
-  hexGenPanel.appendChild(back);
+  hexMenu.appendChild(back);
 }
 
 async function showOffers() {


### PR DESCRIPTION
## Summary
- ensure hex list always shows 25 numbered hexes
- allow editing non-existent hexes by pre-filling the number
- display generator tables in hex tools

## Testing
- `node --check web/ui.js`
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68640283f4f483329f32ae01d3989967