### PR TITLE
Update hex menu behavior and rulebook

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,7 +23,6 @@
       <section id="hex-gen" style="display:none">
         <section id="hex-content" class="panel"></section>
         <aside id="hex-menu" class="panel"></aside>
-        <aside id="hex-legend" class="panel"></aside>
       </section>
     </main>
   </div>

--- a/web/rulebook.html
+++ b/web/rulebook.html
@@ -64,6 +64,14 @@
             <li>Discovery</li>
           </ol>
         </section>
+        <section id="hex-legend">
+          <h2>Hex Map Legend</h2>
+          <p># : Current Location</p>
+          <p>X : Mission Location</p>
+          <p>! : Known/Revealed Info</p>
+          <p>? : Side Mission</p>
+          <p>+ : Hex Traversed</p>
+        </section>
         <section id="sin">
           <h2>Sin and Nightmares</h2>
           <p>Each character tracks a <strong>Sin</strong> score on their sheet. The guide may add points when actions defy morality or the character's alignment.</p>
@@ -80,6 +88,7 @@
         <a href="#combat">Combat</a>
         <a href="#equipment">Equipment &amp; Encumbrance</a>
         <a href="#hex-travel">Hex Travel</a>
+        <a href="#hex-legend">Hex Legend</a>
         <a href="#sin">Sin and Nightmares</a>
       </aside>
     </main>

--- a/web/style.css
+++ b/web/style.css
@@ -68,9 +68,6 @@ body {
   gap: 0.5rem;
 }
 
-#hex-legend {
-  flex: 1 1 30%;
-}
 
 #player-map button {
   width: 100%;


### PR DESCRIPTION
## Summary
- align hex tools with other menus
- remove hex legend panel from the main UI
- add hex legend details to the rulebook
- load hex generator info when editing a hex
- rename the `New Character` menu option to `New Player`

## Testing
- `node --check web/ui.js`

------
https://chatgpt.com/codex/tasks/task_e_686411d7bd2483328a4f432381f4404a