### PR TITLE
Load default hex generator when missing

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,6 +12,9 @@ const partyPath = path.join(dataDir, 'party.json');
 const offersPath = path.join(dataDir, 'offers.json');
 const hexGenPath = path.join(dataDir, 'hex_generator.yaml');
 const hexesPath = path.join(dataDir, 'hexes.yaml');
+const defaultHexGen = yaml.load(
+  fs.readFileSync(path.join(__dirname, 'data', 'hex_generator.yaml'), 'utf8')
+);
 
 function loadParty() {
   try {
@@ -41,10 +44,10 @@ function saveOffers(o) {
 
 function loadHexGen() {
   try {
-    return yaml.load(fs.readFileSync(hexGenPath, 'utf8'));
-  } catch {
-    return { hex_generator: { next_hex_number: '001' } };
-  }
+    const data = yaml.load(fs.readFileSync(hexGenPath, 'utf8'));
+    if (data && data.hex_generator) return data;
+  } catch {}
+  return defaultHexGen;
 }
 
 function saveHexGen(data) {

--- a/web/style.css
+++ b/web/style.css
@@ -27,6 +27,11 @@ body {
   gap: 1rem;
 }
 
+/* Ensure the menu always stays on the right */
+#menu {
+  order: 2;
+}
+
 #creator {
   flex: 2 1 70%;
 }
@@ -36,6 +41,7 @@ body {
 }
 
 .panel {
+  order: 1;
   background: #26232f;
   padding: 1rem;
   border: 2px solid #4c4668;


### PR DESCRIPTION
## Summary
- load bundled hex generator yaml as a fallback
- gracefully handle missing hex generator data so dice tables always work

## Testing
- `node --check server.js`
- `node --check web/ui.js`
- `DATA_DIR=/tmp/testdata node server.js &` then `curl -s http://localhost:3000/api/hex/generate | head`

------
https://chatgpt.com/codex/tasks/task_e_6864266792208332a01ea52280c3de8f