### PR TITLE
Add simple manual hex mapping interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ node server.js
 The server listens on the port defined by the `PORT` environment variable (or
 `3000` by default) and provides a landing page with links to the player and
 guide options.
+
+## Hex Exploration Map
+
+A minimalist map interface is available at `web/hexmap.html`. Launch the server
+with `node server.js` and open this file in a browser. Each hex can store a
+note describing landmarks or rumors discovered during play.

--- a/server.js
+++ b/server.js
@@ -178,6 +178,27 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  if (req.method === 'POST' && req.url === '/api/hex/note') {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', () => {
+      try {
+        const { hex, note } = JSON.parse(body);
+        const all = loadHexes();
+        const hx = all[hex] || {};
+        hx.note = note;
+        all[hex] = hx;
+        saveHexes(all);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Failed to save note');
+      }
+    });
+    return;
+  }
+
   if (req.method === 'GET' && req.url === '/api/hexes') {
     const hx = loadHexes();
     res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/web/hexmap.html
+++ b/web/hexmap.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hex Explorer</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Jacquard+24&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background: #1a1a1a;
+      font-family: 'Pixelify Sans', sans-serif;
+      color: #e0e0e0;
+      display: flex;
+      justify-content: center;
+      padding: 2rem;
+    }
+    #hex-grid {
+      display: flex;
+      flex-direction: column;
+      row-gap: 4px;
+    }
+    .hex-row {
+      display: flex;
+      column-gap: 4px;
+    }
+    .hex-row.offset {
+      margin-left: 32px;
+    }
+    .hex-cell {
+      width: 64px;
+      height: 56px;
+      clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+      background: #2d2c34;
+      border: 2px solid #4c4668;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      cursor: pointer;
+      font-family: 'Jacquard 24', serif;
+    }
+    #editor {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #26232f;
+      border: 2px solid #4c4668;
+      padding: 1rem;
+      z-index: 1000;
+    }
+    #editor textarea {
+      width: 100%;
+      height: 80px;
+      background: #3b364d;
+      border: 2px solid #4c4668;
+      color: #e0e0e0;
+      font-family: 'Pixelify Sans', sans-serif;
+    }
+    #editor button {
+      margin-top: 0.5rem;
+      padding: 0.3rem 0.5rem;
+      background: #3b364d;
+      color: #e0e0e0;
+      border: 2px solid #4c4668;
+      cursor: pointer;
+      font-family: inherit;
+    }
+  </style>
+</head>
+<body>
+  <div id="hex-grid"></div>
+
+  <div id="editor" style="display:none;">
+    <textarea id="note"></textarea>
+    <div style="text-align:right;">
+      <button id="saveNote">Save</button>
+      <button id="cancelNote">Cancel</button>
+    </div>
+  </div>
+
+  <script src="hexmap.js"></script>
+</body>
+</html>

--- a/web/hexmap.js
+++ b/web/hexmap.js
@@ -1,0 +1,65 @@
+const grid = document.getElementById('hex-grid');
+const editor = document.getElementById('editor');
+const noteField = document.getElementById('note');
+let currentHex = null;
+let hexData = {};
+
+async function loadHexes() {
+  try {
+    const res = await fetch('/api/hexes');
+    if (res.ok) hexData = await res.json();
+  } catch (err) {
+    console.error('Failed to load hex data');
+  }
+}
+
+function renderGrid() {
+  grid.innerHTML = '';
+  for (let r = 0; r < 5; r++) {
+    const row = document.createElement('div');
+    row.className = 'hex-row';
+    if (r % 2 === 1) row.classList.add('offset');
+    for (let c = 0; c < 5; c++) {
+      const num = (r * 5 + c + 1).toString().padStart(3, '0');
+      const cell = document.createElement('div');
+      cell.className = 'hex-cell';
+      cell.dataset.hex = num;
+      cell.textContent = num;
+      const note = hexData[num]?.note;
+      if (note) cell.title = note;
+      cell.addEventListener('click', () => openEditor(num));
+      row.appendChild(cell);
+    }
+    grid.appendChild(row);
+  }
+}
+
+function openEditor(num) {
+  currentHex = num;
+  noteField.value = hexData[num]?.note || '';
+  editor.style.display = 'block';
+  noteField.focus();
+}
+
+document.getElementById('saveNote').addEventListener('click', async () => {
+  if (!currentHex) return;
+  const note = noteField.value.trim();
+  try {
+    await fetch('/api/hex/note', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hex: currentHex, note })
+    });
+    hexData[currentHex] = { ...(hexData[currentHex] || {}), note };
+    renderGrid();
+  } catch (err) {
+    console.error('Failed to save note');
+  }
+  editor.style.display = 'none';
+});
+
+document.getElementById('cancelNote').addEventListener('click', () => {
+  editor.style.display = 'none';
+});
+
+loadHexes().then(renderGrid);

--- a/web/index.html
+++ b/web/index.html
@@ -20,11 +20,14 @@
       <section id="creator" class="panel" style="display:none"></section>
       <section id="guide-edit" class="panel" style="display:none"></section>
       <section id="story" class="panel" style="display:none"></section>
-      <section id="hex-gen" style="display:none">
-        <section id="hex-content" class="panel"></section>
-        <aside id="hex-menu" class="panel"></aside>
-      </section>
-    </main>
+    <section id="hex-gen" style="display:none">
+      <section id="hex-content" class="panel"></section>
+      <aside id="hex-menu" class="panel"></aside>
+    </section>
+    <footer style="text-align:center;margin-top:1rem;">
+      <a href="hexmap.html">Simple Hex Map</a>
+    </footer>
+  </main>
   </div>
   <script src="ui.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a minimal hex map interface with note editing
- expose new `/api/hex/note` endpoint for saving notes
- link to the new map from the main UI
- document how to use the hex map

## Testing
- `node -c server.js`
- `node -c web/hexmap.js`

------
https://chatgpt.com/codex/tasks/task_e_686453905f708332a0838a6301c25e1d