### PR TITLE
Remove hex generator, add smaller map

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ in a browser to try a simple menu styled in the spirit of classic text RPGs.
 The UI uses the [Jacquard 24](https://fonts.google.com/specimen/Jacquard+24)
 font from Google Fonts.
 
-**Note:** Features like creating new characters or editing hexes require the
+**Note:** Features like creating new characters or editing map notes require the
 API endpoints served by `server.js`. Make sure the server is running before
 using these options.
 
@@ -64,3 +64,9 @@ node server.js
 The server listens on the port defined by the `PORT` environment variable (or
 `3000` by default) and provides a landing page with links to the player and
 guide options.
+
+## Map
+
+The web interface includes a simple hex map accessed from the Player or Guide
+menus. Launch the server with `node server.js` and open `web/index.html`.
+Choose **Map** from a menu to open the grid and record notes about each hex.

--- a/web/hexmap.html
+++ b/web/hexmap.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Map</title>
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Jacquard+24&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    body {
+      background: #1a1a1a;
+      font-family: 'Pixelify Sans', sans-serif;
+      color: #e0e0e0;
+      display: flex;
+      justify-content: center;
+      padding: 2rem;
+    }
+    #hex-grid {
+      display: flex;
+      flex-direction: column;
+      row-gap: 4px;
+    }
+    .hex-row {
+      display: flex;
+      column-gap: 4px;
+    }
+    .hex-row.offset {
+      margin-left: 20px;
+    }
+    .hex-cell {
+      width: 40px;
+      height: 34px;
+      clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+      background: #2d2c34;
+      border: 2px solid #4c4668;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      cursor: pointer;
+      font-family: 'Jacquard 24', serif;
+    }
+    #editor {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #26232f;
+      border: 2px solid #4c4668;
+      padding: 1rem;
+      z-index: 1000;
+    }
+    #editor textarea {
+      width: 100%;
+      height: 80px;
+      background: #3b364d;
+      border: 2px solid #4c4668;
+      color: #e0e0e0;
+      font-family: 'Pixelify Sans', sans-serif;
+    }
+    #editor button {
+      margin-top: 0.5rem;
+      padding: 0.3rem 0.5rem;
+      background: #3b364d;
+      color: #e0e0e0;
+      border: 2px solid #4c4668;
+      cursor: pointer;
+      font-family: inherit;
+    }
+  </style>
+</head>
+<body>
+  <div id="hex-grid"></div>
+
+  <div id="editor" style="display:none;">
+    <textarea id="note"></textarea>
+    <div style="text-align:right;">
+      <button id="saveNote">Save</button>
+      <button id="cancelNote">Cancel</button>
+    </div>
+  </div>
+
+  <script src="hexmap.js"></script>
+</body>
+</html>

--- a/web/hexmap.js
+++ b/web/hexmap.js
@@ -1,0 +1,65 @@
+const grid = document.getElementById('hex-grid');
+const editor = document.getElementById('editor');
+const noteField = document.getElementById('note');
+let currentHex = null;
+let hexData = {};
+
+async function loadHexes() {
+  try {
+    const res = await fetch('/api/hexes');
+    if (res.ok) hexData = await res.json();
+  } catch (err) {
+    console.error('Failed to load hex data');
+  }
+}
+
+function renderGrid() {
+  grid.innerHTML = '';
+  for (let r = 0; r < 10; r++) {
+    const row = document.createElement('div');
+    row.className = 'hex-row';
+    if (r % 2 === 1) row.classList.add('offset');
+    for (let c = 0; c < 10; c++) {
+      const num = (r * 10 + c + 1).toString().padStart(3, '0');
+      const cell = document.createElement('div');
+      cell.className = 'hex-cell';
+      cell.dataset.hex = num;
+      cell.textContent = num;
+      const note = hexData[num]?.note;
+      if (note) cell.title = note;
+      cell.addEventListener('click', () => openEditor(num));
+      row.appendChild(cell);
+    }
+    grid.appendChild(row);
+  }
+}
+
+function openEditor(num) {
+  currentHex = num;
+  noteField.value = hexData[num]?.note || '';
+  editor.style.display = 'block';
+  noteField.focus();
+}
+
+document.getElementById('saveNote').addEventListener('click', async () => {
+  if (!currentHex) return;
+  const note = noteField.value.trim();
+  try {
+    await fetch('/api/hex/note', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hex: currentHex, note })
+    });
+    hexData[currentHex] = { ...(hexData[currentHex] || {}), note };
+    renderGrid();
+  } catch (err) {
+    console.error('Failed to save note');
+  }
+  editor.style.display = 'none';
+});
+
+document.getElementById('cancelNote').addEventListener('click', () => {
+  editor.style.display = 'none';
+});
+
+loadHexes().then(renderGrid);

--- a/web/index.html
+++ b/web/index.html
@@ -20,11 +20,8 @@
       <section id="creator" class="panel" style="display:none"></section>
       <section id="guide-edit" class="panel" style="display:none"></section>
       <section id="story" class="panel" style="display:none"></section>
-      <section id="hex-gen" style="display:none">
-        <section id="hex-content" class="panel"></section>
-        <aside id="hex-menu" class="panel"></aside>
-      </section>
-    </main>
+    <footer style="text-align:center;margin-top:1rem;"></footer>
+  </main>
   </div>
   <script src="ui.js"></script>
 </body>

--- a/web/style.css
+++ b/web/style.css
@@ -57,50 +57,24 @@ body {
   flex: 2 1 70%;
 }
 
-#hex-gen {
-  flex: 2 1 70%;
-  display: flex;
-  gap: 1rem;
-}
-
-#hex-content {
-  flex: 2 1 70%;
-}
-
-#hex-menu {
-  flex: 1 1 30%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-
-#player-map button {
-  width: 100%;
-}
-
-#hex-grid button {
-  width: 100%;
-}
-
 #hex-grid {
   display: flex;
   flex-direction: column;
-  row-gap: 4px;
+  row-gap: 2px;
 }
 
 .hex-row {
   display: flex;
-  column-gap: 4px;
+  column-gap: 2px;
 }
 
 .hex-row.offset {
-  margin-left: 30px;
+  margin-left: 20px;
 }
 
 .hex-cell {
-  width: 60px;
-  height: 52px;
+  width: 40px;
+  height: 34px;
   clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
   background: #3b364d;
   color: #e0e0e0;


### PR DESCRIPTION
## Summary
- drop the old hex generator endpoints and UI
- rename the map menu option and link it from player and guide menus
- shrink map hexes to fit a 10x10 grid
- simplify README notes about using the Map

## Testing
- `node -c server.js`
- `node -c web/hexmap.js`
- `node -c web/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_686453905f708332a0838a6301c25e1d